### PR TITLE
SAN-9014 : add null check before using callbackContext

### DIFF
--- a/src/android/BrightcoveActivity.java
+++ b/src/android/BrightcoveActivity.java
@@ -181,10 +181,12 @@ public class BrightcoveActivity extends BrightcovePlayer {
 
     private void sendCallback(String status) {
         CallbackContext callbackContext = CordovaBrightcoveCallbackUtil.getInstance().getCallbackContext();
-        try {
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, this.callbackBuilder(status)));
-        } catch (JSONException exception) {
-            callbackContext.error("Error building callback");
+        if (callbackContext != null) {
+            try {
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, this.callbackBuilder(status)));
+            } catch (JSONException exception) {
+                callbackContext.error("Error building callback");
+            }
         }
     }
 


### PR DESCRIPTION
Fix for https://sanvello.atlassian.net/browse/SAN-9014

This prevents the NullPointerException in the crash logs but I wasn't able to identify how we got into the situation in the first place. I'm a bit concerned that this is a symptom of some other issue people are encountering, but this should at least fail more gracefully.
