### PR TITLE
SAN-9025 : don't attempt to calculate percent complete on empty optio…

### DIFF
--- a/src/ios/PlayerViewController.swift
+++ b/src/ios/PlayerViewController.swift
@@ -155,14 +155,17 @@ class PlayerViewController: UIViewController, BCOVPlaybackControllerDelegate, BC
             
             callbackMessage["status"] = self.callBackStatus
             
+            var percentage = 0.0
+            
             if (self.callBackStatus == "completed") {
-                callbackMessage["percentage"] = 100
-            } else {
-                let percentage = ((self.progress! * 100) / self.duration!).rounded()
-                callbackMessage["percentage"] = percentage
+                percentage = 100
+            } else if let progress = self.progress, let duration = self.duration, duration != 0 {
+                percentage = ((progress * 100) / duration).rounded()
             }
             
-            self.delegate!.callBackMessage(callbackMessage: callbackMessage)
+            callbackMessage["percentage"] = percentage
+            
+            self.delegate?.callBackMessage(callbackMessage: callbackMessage)
             self.clear()
         })
     }


### PR DESCRIPTION
Fix for https://sanvello.atlassian.net/browse/SAN-9025

The issue was caused by calculating percentage playback complete when duration is zero. There were other potential issues where optional values were force unwrapped that could cause a crash.